### PR TITLE
fix(b2cleaner): fixes deletion of files

### DIFF
--- a/dailybkup/b2utils.py
+++ b/dailybkup/b2utils.py
@@ -1,9 +1,9 @@
-from sys import prefix
 import b2sdk.v2 as b2sdk  # type: ignore
 import tempfile
+import logging
 from typing import Iterator
 
-
+logger = logging.getLogger(__name__)
 DELETE_ALL_FILES_WHITELIST = ["dailybkup-test"]
 
 
@@ -56,8 +56,10 @@ class B2Context:
         )
 
     def delete(self, file_name: str) -> None:
-        for file_version, _ in self._bucket.ls(self.prefix, recursive=True):
+        for file_version, _ in self._bucket.ls(folder_to_list=f"{self.prefix}*", with_wildcard=True, latest_only=False, recursive=True):
+            logger.debug(f"Checking {file_version.file_name}")
             if file_version.file_name == f"{self.prefix}{file_name}":
+                logger.debug(f"Deleting {file_version.file_name}")
                 self._bucket.delete_file_version(
                     file_version.id_, file_version.file_name
                 )

--- a/devtools/b2client.py
+++ b/devtools/b2client.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+"""
+A helper script that allows you to test whether the google drive client is working.
+"""
+import logging
+import typer
+from dailybkup import b2utils
+
+app = typer.Typer()
+
+@app.callback()
+def setup(
+    ctx: typer.Context,
+    application_key_id: str = typer.Option(..., envvar="DAILYBKUP_B2_APPLICATION_KEY_ID"),
+    application_key: str = typer.Option(..., envvar="DAILYBKUP_B2_APPLICATION_KEY"),
+    bucket_name: str = typer.Option(..., envvar="DAILYBKUP_B2_BUCKET_NAME"),
+    prefix: str = typer.Option("", envvar="DAILYBKUP_B2_PREFIX"),
+    log_level: str = typer.Option("DEBUG", envvar="LOG_LEVEL"),
+):
+    logging.basicConfig(level=log_level)
+    b2context = b2utils.B2Context(
+        application_key_id=application_key_id,
+        application_key=application_key,
+        bucket_name=bucket_name,
+        prefix=prefix,
+    )
+    ctx.obj = b2context
+
+@app.command()
+def delete_file(file_name: str, ctx: typer.Context):
+    """
+    Delete a file from the bucket based on it's name.
+    """
+    b2context = ctx.obj
+    b2context.delete(file_name)
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
Files were not being deleted from `b2` because we called `bucket.ls`
in a way that we didn't see all files.

Also add a new helper `dev` CLI to interact directly with the b2
client for local testing.
